### PR TITLE
Updating dome and safety models

### DIFF
--- a/coffee/models/mtcs/dome/software.coffee
+++ b/coffee/models/mtcs/dome/software.coffee
@@ -489,9 +489,7 @@ MTCS_MAKE_STATEMACHINE THISLIB, "DomeRotation",
                                                         self.processes.stop),
                                     NOT(self.masterSlaveLagError),
                                     OR(self.isHomed, NOT(self.initializationStatus.initialized)))
-
-#                                    NOT(AND(NOT(self.isHomed), self.initializationStatus.initialized)))
-hasWarning            : -> MTCS_SUMMARIZE_WARN(self.parts.masterAxis,
+      hasWarning            : -> MTCS_SUMMARIZE_WARN(self.parts.masterAxis,
                                                      self.parts.slaveAxis,
                                                      self.parts.drive,
                                                      self.processes.reset,

--- a/coffee/models/mtcs/safety/software.coffee
+++ b/coffee/models/mtcs/safety/software.coffee
@@ -556,7 +556,7 @@ MTCS_MAKE_STATEMACHINE THISLIB, "SafetyDomeAccess",
                                          self.processes.stopBypassing.statuses.busyStatus.busy )
         healthStatus:
             isGood              : -> NOT( OR( self.groupComError, self.groupFbError, self.groupOutError) )
-            hasWarning          : -> AND( OR(self.activityStatus.awake, self.activityStatus.moving), OR(self.personHasEntered, self.sensorsBypassedPermanently))
+            hasWarning          : -> OR( self.personHasEntered, self.sensorsBypassedPermanently )
         reset:
             isEnabled           : -> self.statuses.busyStatus.idle
         personHasLeft:


### PR DESCRIPTION
- Correcting a bug in dome rotation statuses section. Because of this dome rotation status was always in Idle.
- Updating safety to allow the change to warning status when personHasEntered or sensorsBypassedPermanently, even if telescope is not awake.